### PR TITLE
Add basic AppV2 compatability

### DIFF
--- a/actor-sounds.js
+++ b/actor-sounds.js
@@ -48,7 +48,7 @@ export class ActorSounds {
             sheetNames.forEach((sheetName) => {
                 Hooks.on("render" + sheetName, (app, html, data) => {
                     // only for GMs or the owner of this npc
-                    if (!app.object.isOwner || !data.actor) return;
+                    if (!(app.object instanceof Actor) || !(app.object?.isOwner ?? app.document?.isOwner)) return;
 
                     // don't add the button multiple times
                     if ($(html).find("#mseCharacterSound").length > 0) return;

--- a/actor-sounds.js
+++ b/actor-sounds.js
@@ -48,7 +48,7 @@ export class ActorSounds {
             sheetNames.forEach((sheetName) => {
                 Hooks.on("render" + sheetName, (app, html, data) => {
                     // only for GMs or the owner of this npc
-                    if (!(app.object instanceof Actor) || !(app.object?.isOwner ?? app.document?.isOwner)) return;
+                    if ((!(app.object instanceof Actor) && !(app.document instanceof Actor)) || !(app.object?.isOwner ?? app.document?.isOwner)) return;
 
                     // don't add the button multiple times
                     if ($(html).find("#mseCharacterSound").length > 0) return;

--- a/actor-sounds.js
+++ b/actor-sounds.js
@@ -87,7 +87,7 @@ export class ActorSounds {
             itemSheetNames.forEach((sheetName) => {
                 Hooks.on("render" + sheetName, (app, html, data) => {
                     // only for GMs or the owner of this npc
-                    if (!app.object.isOwner) return;
+                    if (!(app.object?.isOwner ?? app.document?.isOwner)) return;
     
                     // don't add the button multiple times
                     if ($(html).find("#mseItemSound").length > 0) return;


### PR DESCRIPTION
Currently sound controls are added based on calls to `renderActorSheet` and `renderItemSheet`, for systems like the one I'm developing that are moving over to AppV2, these hooks aren't called as they have been replaced with `renderActorSheetV2` and `renderItemSheetV2`.

Updated the hooks here so they call both app v1 and v2 hooks.

Besides this, `app.object` is no longer in use, for my system's compatability sake, I've added getters to my actor/item sheets to resolve this, but I've included a patch that should work for the majority of systems otherwise.